### PR TITLE
Fix performance issue with changes on options

### DIFF
--- a/src/sq-datetimepicker/sq-datetimepicker.component.ts
+++ b/src/sq-datetimepicker/sq-datetimepicker.component.ts
@@ -70,7 +70,7 @@ export class SqDatetimepickerComponent implements OnInit, OnChanges, OnDestroy, 
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (this.dpObject && changes && changes['options']) {
+    if (this.dpObject && changes && changes['options'] && JSON.stringify(changes['options'].currentValue) != JSON.stringify(changes['options'].previousValue)) {
       this.dpObject.options(this.options);
     }
   }

--- a/src/sq-datetimepicker/sq-datetimepicker.component.ts
+++ b/src/sq-datetimepicker/sq-datetimepicker.component.ts
@@ -53,6 +53,7 @@ export class SqDatetimepickerComponent implements OnInit, OnChanges, OnDestroy, 
   @Output() dpHide: EventEmitter<HideEventObject> = new EventEmitter<HideEventObject>();
   @Output() dpShow: EventEmitter<any> = new EventEmitter<any>();
   @Output() dpUpdate: EventEmitter<UpdateEventObject> = new EventEmitter<UpdateEventObject>();
+  @Output() dpInit: EventEmitter<any> = new EventEmitter<any>();
 
   private parseError: boolean;
   private dpElement: any;
@@ -125,6 +126,9 @@ export class SqDatetimepickerComponent implements OnInit, OnChanges, OnDestroy, 
     options.inline = this.mode === 'inline';
     this.dpElement.datetimepicker(options);
     this.dpObject = this.dpElement.data('DateTimePicker');
+    if(this.dpObject){
+      this.dpInit.emit(this.dpObject);
+    }  
     this.bindEvents();
   }
 


### PR DESCRIPTION
Performance issue.
as zone.js could refresh view multiple times, and as ngOnChanges will be evaluate also multiple times, we should only called  the method this.dpObject.options(this.options) only if options has really changed.
this.dpObject.options(this.options) is too heavy and must be called only if it really needed.
I got this problem when the component is conditioned with an ngIf with an observable | async.